### PR TITLE
add CDN property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,6 +1708,12 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "hanbi": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/hanbi/-/hanbi-0.4.1.tgz",
+      "integrity": "sha512-z5UYPq/+PfDDT7uZ/IrO4e5BhWcNnR73oP6CUaDUERbskABmBqrDzfePktI0BIPAV4xfyAhue8ZTmyCOh7rZ3g==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@web/test-runner-puppeteer": "^0.9.3",
     "eslint": "^7.20.0",
     "eslint-config-google": "^0.14.0",
+    "hanbi": "^0.4.1",
     "mocha": "^8.3.0",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",

--- a/src/shiki-element.ts
+++ b/src/shiki-element.ts
@@ -36,6 +36,18 @@ export class ShikiHighlightElement extends HTMLElement {
   };
 
   /**
+   * Sets the CDN for shiki to load resources from.
+   *
+   * This can be local, e.g. "/node_modules".
+   *
+   * @param {string} val CDN path to set
+   */
+  public set cdn(val: string) {
+    shiki.setCDN(val);
+    this._initialiseHighlighter();
+  }
+
+  /**
    * Gets the language we want to highlight
    */
   public get language(): string {

--- a/src/test/shiki-element_test.ts
+++ b/src/test/shiki-element_test.ts
@@ -1,8 +1,9 @@
 import * as assert from 'uvu/assert';
-import {setCDN} from 'shiki/dist/index.browser.mjs';
+import * as shiki from 'shiki/dist/index.browser.mjs';
 import {ShikiHighlightElement} from '../shiki-element.js';
+import * as hanbi from 'hanbi';
 
-setCDN('/node_modules/shiki/');
+shiki.setCDN('/node_modules/shiki/');
 
 const waitForSelector = (
   node: HTMLElement | DocumentFragment,
@@ -44,6 +45,7 @@ describe('shiki-highlight', () => {
 
   afterEach(() => {
     element.remove();
+    hanbi.restore();
   });
 
   it('should upgrade to the correct element and set defaults', () => {
@@ -87,6 +89,16 @@ describe('shiki-highlight', () => {
 
       element.options = {theme: 'github-light'};
       await waitForFunction(() => element.shadowRoot!.innerHTML !== contents);
+    });
+  });
+
+  describe('CDN', () => {
+    it('should exist', async () => {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(element),
+        'cdn'
+      );
+      assert.ok(descriptor?.set);
     });
   });
 });


### PR DESCRIPTION
otherwise in some cases its impossible to set it correctly before render...

```ts
import * as shiki from 'shiki';
import 'shiki-element';

shiki.setCDN('/'); // modules are always deferred, this will almost always run after the DOM was created, and thus first render began
```