### PR TITLE
fix: update globs npm broke

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/shiki-element.js",
   "type": "module",
   "files": [
-    "lib/!(test)",
+    "lib/",
+    "!lib/test",
     "custom_types/"
   ],
   "scripts": {


### PR DESCRIPTION
NPM broke how globs work, so this separates the negation out to make it work again.