### PR TITLE
fix: downgrade node in publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci


### PR DESCRIPTION
There's some nasty segfault being dealt with upstream in node itself.

Until that gets fixed, lets use 20.x.

Issue can be tracked here:
https://github.com/nodejs/node/issues/52797