### PR TITLE
fix: overflow auto the output by default

### DIFF
--- a/src/shiki-element.ts
+++ b/src/shiki-element.ts
@@ -21,6 +21,7 @@ stylesheet.replaceSync(`
   pre.shiki {
     margin: 0;
     padding: var(--shiki-padding, .4em);
+    overflow: var(--shiki-overflow, auto);
   }
 `);
 


### PR DESCRIPTION
Adds scrolling when necessary, but can be overridden by `--shiki-overflow`.